### PR TITLE
Issue 31: LCM does not reference a tagged release version of meta-amx…

### DIFF
--- a/manifests/rdkbb-apps-lcm.xml
+++ b/manifests/rdkbb-apps-lcm.xml
@@ -4,8 +4,8 @@
             fetch="https://gitlab.com/prpl-foundation/prplrdkb/metalayers/"
             review="https://gitlab.com/prpl-foundation/prplrdkb/metalayers/"/>
 
-    <project remote="prpl-foundation" name="meta-amx" path="meta-amx" revision="master"/>
-    <project remote="prpl-foundation" name="meta-lcm" path="meta-lcm" revision="master"/>
+    <project remote="prpl-foundation" name="meta-amx" path="meta-amx" revision="prplos-3.1.0"/>
+    <project remote="prpl-foundation" name="meta-lcm" path="meta-lcm" revision="prplos-3.1.0"/>
 
 </manifest>
 


### PR DESCRIPTION


Both layers now reference the release tag - prplos-v3.1.0, following lcm and amx feed tagging scheme.

On branch 31-bug-lcm-does-not-reference-a-tagged-release-version-of-meta-amx-meta-lcm Changes to be committed:
	modified:   manifests/rdkbb-apps-lcm.xml