### PR TITLE
RDKBACCL-1381 : Cherry-pick the scarthgap changes to rdkb-bpi-2025q4 branch

### DIFF
--- a/recipes-containers/dobby/dobby.bbappend
+++ b/recipes-containers/dobby/dobby.bbappend
@@ -1,4 +1,4 @@
 #WPEFramework dependecy is added in dobby.bb, removing that
-RDEPENDS_${PN} = ""
+RDEPENDS:${PN} = ""
 #Below flag enables dobby to create run-time containers using json spec
 PACKAGECONFIG:append = " legacycomponents"


### PR DESCRIPTION
Reason for change: Fixing unbuildable dependency for dobby in scarthgap
Risks: Low
Test Procedure: None