### PR TITLE
-65 Update LCM submanifest tags to prplware-v4.1.0

### DIFF
--- a/manifests/rdkbb-apps-lcm.xml
+++ b/manifests/rdkbb-apps-lcm.xml
@@ -4,8 +4,8 @@
             fetch="https://gitlab.com/prpl-foundation/prplrdkb/metalayers/"
             review="https://gitlab.com/prpl-foundation/prplrdkb/metalayers/"/>
 
-    <project remote="prpl-foundation" name="meta-amx" path="meta-amx" revision="refs/tags/prplos-v3.1.0"/>
-    <project remote="prpl-foundation" name="meta-lcm" path="meta-lcm" revision="refs/tags/prplos-v3.1.0"/>
+    <project remote="prpl-foundation" name="meta-amx" path="meta-amx" revision="refs/tags/prplware-v4.1.0"/>
+    <project remote="prpl-foundation" name="meta-lcm" path="meta-lcm" revision="refs/tags/prplware-v4.1.0"/>
 
 </manifest>
 


### PR DESCRIPTION
Update LCM submanifest tags to new release "prplware-v4.1.0"
