### PR TITLE
RDKBACCL-1828: Make 6.12 kernel build changes in wrynose build

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -4,7 +4,7 @@ BBFILE_PATTERN_rdkbbapps = "^${LAYERDIR}/"
 BBFILE_PRIORITY_rdkbbapps = "7"
 
 # Yocto/OE compatibility: Need to adjust to appropriate target
-LAYERSERIES_COMPAT_rdkbbapps = "kirkstone mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_rdkbbapps = "kirkstone mickledore nanbield scarthgap wrynose"
 
 # Where to scan for recipes
 BBPATH .= ":${LAYERDIR}"


### PR DESCRIPTION
Reason for change : Added wrynose compat support to this layer
Test procedure: None
Risk: None